### PR TITLE
Prescouting changes

### DIFF
--- a/src/components/context/CurrentMatchContext.ts
+++ b/src/components/context/CurrentMatchContext.ts
@@ -5,6 +5,8 @@ export type CurrentMatchContextType = {
     hasUpdate: boolean,
     update: ()=>void,
     incrementAndUpdate: ()=>void,
+    shouldAutoUpdate: boolean,
+    setShouldAutoUpdate: (autoUpdate: boolean)=>void,
 }
 
 const CurrentMatchContext = createContext<CurrentMatchContextType|undefined>(undefined);

--- a/src/components/context/CurrentMatchContextProvider.tsx
+++ b/src/components/context/CurrentMatchContextProvider.tsx
@@ -16,7 +16,9 @@ export default function CurrentMatchContextProvider({children}: {children: React
     const [scoutingData, setScoutingData] = useState<{matchId: string, teamNumber: number, allianceColor: AllianceColor} | undefined>(undefined);
 
     const [hasUpdate, setHasUpdate] = useState(false);
+    const [shouldAutoUpdate, setShouldAutoUpdate] = useState(true);
     const [updateNextRender, setUpdateNextRender] = useState(true); // Update on page load
+
 
     /**
      * Updates the current match being scouting, may clear any in-progress data. 
@@ -51,7 +53,11 @@ export default function CurrentMatchContextProvider({children}: {children: React
     }
 
     useEffect(() => {
-        setHasUpdate(true);
+        if (shouldAutoUpdate) {
+            update();
+        } else {
+            setHasUpdate(true);
+        }
     }, [settings.currentMatchIndex, settings.clientId, settings.matches]);
 
     useEffect(() => {
@@ -61,7 +67,7 @@ export default function CurrentMatchContextProvider({children}: {children: React
     }, [updateNextRender]);
 
     return (
-        <CurrentMatchContext.Provider value={{setHasUpdate, hasUpdate, update, incrementAndUpdate}}>
+        <CurrentMatchContext.Provider value={{setHasUpdate, hasUpdate, update, incrementAndUpdate, shouldAutoUpdate, setShouldAutoUpdate}}>
             <ConditionalWrapper 
                 condition={scoutingData} 
                 wrapper={(children) => 

--- a/src/pages/scout/PreMatch.tsx
+++ b/src/pages/scout/PreMatch.tsx
@@ -68,20 +68,21 @@ const PreMatch = () => {
                     {context.meta.teamNumber}
                 </span>
                 <span> in match </span>
-                <Select
-                    labelId="match-select-label"
-                    id="match-select"
-                    value={context.meta.matchId}
-                    onChange={(event) => {
-                        let index = settings.matches.map((match) => match.matchId+"").indexOf(event.target.value);
-                        settings?.setCurrentMatchIndex(index);
-                    }}
-                    label="Select Match"
-                >
-                    {settings.matches.map((match) => {
-                        return <MenuItem value={match.matchId+""}>{match.matchId}</MenuItem>;
-                    })}
-                </Select>
+                <FormControl variant="standard">
+                    <Select
+                        labelId="match-select-label"
+                        id="match-select"
+                        value={context.meta.matchId}
+                        onChange={(event) => {
+                            let index = settings.matches.map((match) => match.matchId+"").indexOf(event.target.value);
+                            settings?.setCurrentMatchIndex(index);
+                        }}
+                        label="Select Match">
+                        {settings.matches.map((match) => {
+                            return <MenuItem value={match.matchId+""}><b>{match.matchId}</b></MenuItem>;
+                        })}
+                    </Select>
+                </FormControl>
             </h1>
             <span className="mb-8 max-w-md text-center text-secondary">If this is the wrong match, use the Next and Previous buttons on the schedule part of the settings page.</span>
             <FormControl sx={{ m: 1, minWidth: 224 }}>

--- a/src/pages/scout/PreMatch.tsx
+++ b/src/pages/scout/PreMatch.tsx
@@ -1,7 +1,7 @@
 import InputLabel from "@mui/material/InputLabel/InputLabel";
 import MenuItem from "@mui/material/MenuItem/MenuItem";
 import Select, { SelectChangeEvent } from "@mui/material/Select/Select";
-import { useContext, useEffect, useRef } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import ScoutingContext from "../../components/context/ScoutingContext";
 import NoMatchAvailable from "./NoMatchAvailable";
 import FormControl from "@mui/material/FormControl/FormControl";
@@ -10,7 +10,10 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import HumanPlayerLocation from "../../enums/HumanPlayerLocation";
 import AllianceColor from "../../enums/AllianceColor";
 import SettingsContext from "../../components/context/SettingsContext";
-import { MAX_NOTE_LENGTH } from "../../constants";
+import { DEFAULT_COMPETITION_ID, MAX_NOTE_LENGTH } from "../../constants";
+import { MatchIdentifier } from "../../types/MatchData";
+import MatchDatabase from "../../util/MatchDatabase";
+import matchCompare from "../../util/matchCompare";
 
 
 const PreMatch = () => {
@@ -68,9 +71,20 @@ const PreMatch = () => {
                     {context.meta.teamNumber}
                 </span>
                 <span> in match </span>
-                <span>
-                    {context.meta.matchId}
-                </span>
+                <Select
+                    labelId="match-select-label"
+                    id="match-select"
+                    value={context.meta.matchId}
+                    onChange={(event) => {
+                        let index = settings.matches.map((match) => match.matchId+"").indexOf(event.target.value);
+                        settings?.setCurrentMatchIndex(index);
+                    }}
+                    label="Select Match"
+                >
+                    {settings.matches.map((match) => {
+                        return <MenuItem value={match.matchId+""}>{match.matchId}</MenuItem>;
+                    })}
+                </Select>
             </h1>
             <span className="mb-8 max-w-md text-center text-secondary">If this is the wrong match, use the Next and Previous buttons on the schedule part of the settings page.</span>
             <FormControl sx={{ m: 1, minWidth: 224 }}>

--- a/src/pages/scout/PreMatch.tsx
+++ b/src/pages/scout/PreMatch.tsx
@@ -1,7 +1,7 @@
 import InputLabel from "@mui/material/InputLabel/InputLabel";
 import MenuItem from "@mui/material/MenuItem/MenuItem";
 import Select, { SelectChangeEvent } from "@mui/material/Select/Select";
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef } from "react";
 import ScoutingContext from "../../components/context/ScoutingContext";
 import NoMatchAvailable from "./NoMatchAvailable";
 import FormControl from "@mui/material/FormControl/FormControl";
@@ -10,10 +10,7 @@ import { Link, NavLink, useNavigate } from "react-router-dom";
 import HumanPlayerLocation from "../../enums/HumanPlayerLocation";
 import AllianceColor from "../../enums/AllianceColor";
 import SettingsContext from "../../components/context/SettingsContext";
-import { DEFAULT_COMPETITION_ID, MAX_NOTE_LENGTH } from "../../constants";
-import { MatchIdentifier } from "../../types/MatchData";
-import MatchDatabase from "../../util/MatchDatabase";
-import matchCompare from "../../util/matchCompare";
+import { MAX_NOTE_LENGTH } from "../../constants";
 
 
 const PreMatch = () => {

--- a/src/pages/scout/ScoutLayout.tsx
+++ b/src/pages/scout/ScoutLayout.tsx
@@ -42,6 +42,11 @@ const ScoutPage = () => {
         }
     }, [currentMatchContext?.hasUpdate]);
 
+    useEffect(() => {
+        if (context == undefined) return;
+        currentMatchContext?.setShouldAutoUpdate(context.match.events.length == 0);
+    }, [context]);
+
     const [warningDismissed, setWarningDismissed] = useState(false);
 
     function startMatch() {


### PR DESCRIPTION
There is now an option to change which match you are currently scouting from the pre scouting page.
Additionally, the match context now updates automatically as long as there is no currently running match, this should remove the yellow box about that in most cases